### PR TITLE
Bump min SDK to Dart 2.18.0 / Flutter 3.3.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,9 @@ jobs:
           echo $(cat .melos_packages) >> $GITHUB_ENV
       - name: Melos Bootstrap
         run: melos bootstrap
+      - run: melos -v
+      - run: ls -la dio
+      - run: cat dio/pubspec_overrides.yaml
       - name: '[Verify step] Format'
         if: ${{ matrix.sdk == 'stable' }}
         run: melos run format

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           cache: true
-          flutter-version: ${{ matrix.sdk == 'min' && '2.8.0' || '' }}
+          flutter-version: ${{ matrix.sdk == 'min' && '3.3.0' || '' }}
           channel: ${{ matrix.sdk == 'min' && '' || matrix.channel }}
       - run: dart pub get
       - uses: bluefireteam/melos-action@v3

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -17,7 +17,7 @@ repository: https://github.com/cfug/dio/blob/main/dio
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
   async: ^2.8.2

--- a/dio_test/lib/src/test/download_tests.dart
+++ b/dio_test/lib/src/test/download_tests.dart
@@ -272,7 +272,7 @@ void downloadTests(
         },
         // The download of the main.zip file can be slow,
         // so we need to increase the timeout.
-        timeout: Timeout(Duration(minutes: 2)),
+        timeout: Timeout(Duration(milliseconds: 1)),
       );
 
       test('delete on error', () async {

--- a/dio_test/lib/src/test/download_tests.dart
+++ b/dio_test/lib/src/test/download_tests.dart
@@ -272,7 +272,7 @@ void downloadTests(
         },
         // The download of the main.zip file can be slow,
         // so we need to increase the timeout.
-        timeout: Timeout(Duration(minutes: 1)),
+        timeout: Timeout(Duration(minutes: 2)),
       );
 
       test('delete on error', () async {

--- a/dio_test/pubspec.yaml
+++ b/dio_test/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/cfug/dio/blob/main/dio_test
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
   dio: any

--- a/example_flutter_app/pubspec.yaml
+++ b/example_flutter_app/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/melos.yaml
+++ b/melos.yaml
@@ -60,13 +60,6 @@ scripts:
     packageFilters:
       flutter: false
       dirExists: test
-    # Old syntax for melos <= 2.9.0 - this can be removed once we bump the minimum Dart SDK.
-    select-package:
-      flutter: false
-      dir-exists: test
-      ignore:
-        - 'dio_compatibility_layer'
-        - 'dio_http2_adapter'
   test:web:
     name: Dart Web tests
     run: |
@@ -91,14 +84,6 @@ scripts:
       ignore:
         - '*http2*'
         - '*cookie*'
-    # Old syntax for melos <= 2.9.0 - this can be removed once we bump the minimum Dart SDK.
-    select-package:
-      flutter: false
-      dir-exists: test
-      ignore:
-        - 'dio_compatibility_layer'
-        - '*http2*'
-        - '*cookie*'
   test:flutter:
     name: Flutter tests
     exec: flutter test --coverage
@@ -107,13 +92,6 @@ scripts:
       dirExists: test
       ignore:
         - '*example*'
-    # Old syntax for melos <= 2.9.0 - this can be removed once we bump the minimum Dart SDK.
-    # There is no packages to run on min SDK for this command.
-    select-package:
-      flutter: true
-      dir-exists: test
-      ignore:
-        - '*'
   test:coverage:
     name: Run all tests and display coverage
     run: |

--- a/plugins/cookie_manager/pubspec.yaml
+++ b/plugins/cookie_manager/pubspec.yaml
@@ -13,7 +13,7 @@ repository: https://github.com/cfug/dio/blob/main/plugins/cookie_manager
 issue_tracker: https://github.com/cfug/dio/issues
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
   cookie_jar: ^4.0.0


### PR DESCRIPTION
This should allow us to use a newer melos version in CI.<!-- Write down your pull request descriptions. -->

### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dev/documentation/dio/latest/)
- [ ] I have searched for a similar pull request in the [project](https://github.com/cfug/dio/pulls) and found none
- [ ] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests without failures
- [ ] I have updated the `CHANGELOG.md` in the corresponding package

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
This should allow us to use a newer melos version in CI.